### PR TITLE
Support loading ecto conditionally [Partial Solution]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,13 +22,17 @@ defmodule GraphQL.Relay.Mixfile do
 
   def application do
     [
-      applications: [:logger, :ecto],
+      applications: applications(Mix.env),
       env: [
         schema_module: StarWars.Schema, # Module with a .schema function that returns your GraphQL schema
         schema_json_path: "./schema.json"
       ]
     ]
   end
+  
+  defp applications(:test), do: applications(:prod) ++ [:ecto]
+  defp applications(:dev), do: applications(:prod) ++ [:ecto]
+  defp applications(_), do: [:logger]
 
   defp deps do
     [


### PR DESCRIPTION
Including graphql_relay in projects which do not use ecto causes problems, because the ecto dependency here is only required for `:test` and `dev`, and is not installed by Mix by default when including graphql_relay as a dependency. This means that the application won't boot, as it can't find `:ecto` on launch.

This PR solves the problem for environments other than `:test` and `:dev`, but does not resolve the case where graphql_relay is used in the `:test` environment of a project which does not use ecto. In that instance (as is the case with my own project) I'm currently forced to include ecto to satisfy the child dependency, even though my own project doesn't use it. I'm not sure how to resolve this — unless there's an elusive `Mix.included_as_a_dependency` (etc.) method that I've missed, which would enable more precise control over app loading!
